### PR TITLE
Fix one error due to missing {, and fix incorrect resource file path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 */.classpath
 */.project
+
+.idea
+patterns depth corpus/
+patterns survey corpus 2017-03-03/

--- a/SemanticChangeGraphMiner/src/mining/Miner.java
+++ b/SemanticChangeGraphMiner/src/mining/Miner.java
@@ -38,7 +38,7 @@ public class Miner {
 		this.level = level;
 	}
 
-	public String getCurrDir()
+	public String getCurrDir() {
 		return currDir;
 	}
 

--- a/SemanticChangeGraphMiner/src/utils/DirectoryHTML.java
+++ b/SemanticChangeGraphMiner/src/utils/DirectoryHTML.java
@@ -82,6 +82,8 @@ public class DirectoryHTML {
                 "});\n" +
                 "</script>");
 
+        sb.append("</body></HTML>");
+
         FileIO.writeStringToFile(sb.toString(), dir + "/directory.html");
     }
 }

--- a/SemanticChangeGraphMiner/src/utils/DirectoryHTML.java
+++ b/SemanticChangeGraphMiner/src/utils/DirectoryHTML.java
@@ -15,11 +15,12 @@ public class DirectoryHTML {
     public void write(HashMap<Integer, ArrayList<ArrayList<String>>> foundPatterns, File dir) {
         //ADD helper Files
         try {
-//            Files.copy(Paths.get("src/resources/sortable.js"),Paths.get("output/patterns/sortable.js"), StandardCopyOption.REPLACE_EXISTING );
-            Files.copy(Paths.get("src/resources/jquery.dataTables.min.css"),Paths.get("output/patterns/jquery.dataTables.min.css"), StandardCopyOption.REPLACE_EXISTING );
-            Files.copy(Paths.get("src/resources/jquery-2.2.3.min.js"),Paths.get("output/patterns/jquery-2.2.3.min.js"), StandardCopyOption.REPLACE_EXISTING );
-            Files.copy(Paths.get("src/resources/default.css"),Paths.get("output/patterns/default.css"), StandardCopyOption.REPLACE_EXISTING );
-            Files.copy(Paths.get("src/resources/highlight.pack.js"),Paths.get("output/patterns/highlight.pack.js"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/sortable.js"),Paths.get("output/patterns/sortable.js"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/jquery.dataTables.min.js"),Paths.get("output/patterns/jquery.dataTables.min.js"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/jquery.dataTables.min.css"),Paths.get("output/patterns/jquery.dataTables.min.css"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/jquery-2.2.3.min.js"),Paths.get("output/patterns/jquery-2.2.3.min.js"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/default.css"),Paths.get("output/patterns/default.css"), StandardCopyOption.REPLACE_EXISTING );
+            Files.copy(Paths.get("SemanticChangeGraphMiner/src/resources/highlight.pack.js"),Paths.get("output/patterns/highlight.pack.js"), StandardCopyOption.REPLACE_EXISTING );
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Thanks for the works. I am recently trying it, and found several errors that should be fixed. 

Since the two projects have been put under one repo, after opening the project in Intellj IDEA and running the MineChangePatterns, the base path of Paths.get() in Miner.java has changed to be the root path of the repo instead of the original SemanticChangeGraphMiner/. In this case, errors are reported:

```java
java.nio.file.NoSuchFileException: src/resources/jquery.dataTables.min.css
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:548)
	at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:258)
	at java.base/java.nio.file.Files.copy(Files.java:1294)
	at utils.DirectoryHTML.write(DirectoryHTML.java:19)
	at mining.Miner.printOutResults(Miner.java:149)
	at mining.Miner.mine(Miner.java:120)
	at main.MineChangePatterns.mine(MineChangePatterns.java:119)
	at main.MineChangePatterns.main(MineChangePatterns.java:101)
java.nio.file.NoSuchFileException: src/resources/jquery.dataTables.min.css
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:548)
	at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:258)
	at java.base/java.nio.file.Files.copy(Files.java:1294)
	at utils.DirectoryHTML.write(DirectoryHTML.java:19)
	at mining.Miner.collectPatternsForNextStep(Miner.java:526)
	at mining.Miner.mine(Miner.java:125)
	at main.MineChangePatterns.mine(MineChangePatterns.java:119)
	at main.MineChangePatterns.main(MineChangePatterns.java:101)

```

In order to fix that, I add the folder name to the relative path, to copy the resource files normally.

However, it still seems that the css and js files are not working for the generated page (see below), neither in the provided corpus nor in my generated output.

![image](https://user-images.githubusercontent.com/14107297/101715005-a2e08400-3ad5-11eb-9615-4e822d21c1ea.png)
